### PR TITLE
tweak(enable unpaged): default value to true

### DIFF
--- a/src/constants.ts
+++ b/src/constants.ts
@@ -14,7 +14,7 @@ export const defaultPaginate: PaginateQuery = {
 export const DEFAULT_MAX_SIZE = 100;
 
 export const defaultPaginateOptions: Required<PaginateOptions> = {
-  enableUnpaged: false,
+  enableUnpaged: true,
   enableSize: true,
   enableSort: true,
   limit: null,


### PR DESCRIPTION
This pull request makes a small but significant change to the default pagination options in `src/constants.ts`. The `enableUnpaged` property in `defaultPaginateOptions` has been updated to `true` to allow unpaged queries by default.